### PR TITLE
Fix/12

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "format": "prettier --check ./src"
   },
   "dependencies": {
+    "@expo/vector-icons": "^10.0.6",
     "@types/styled-components": "^5.0.1",
     "expo": "~37.0.3",
     "react": "~16.9.0",

--- a/src/components/composites/Button/index.tsx
+++ b/src/components/composites/Button/index.tsx
@@ -44,15 +44,15 @@ type IconProps = {
 }
 
 type ButtonProps = IconProps & RippleProps &
-  TouchableWithoutFeedbackProps & 
-  IconProps & {
-    label?: string;
-    block?: boolean;
-    outline?: boolean;
-    transaprent?: boolean;
-    variant?: "critical" | "caution" | "positive" | "neutral" | "info" | "promote";
-    labelStyle?: TextStyle;
-  };
+  TouchableWithoutFeedbackProps &
+{
+  label?: string;
+  block?: boolean;
+  outline?: boolean;
+  transaprent?: boolean;
+  variant?: "critical" | "caution" | "positive" | "neutral" | "info" | "promote";
+  labelStyle?: TextStyle;
+};
 
 /*
 | Default button style
@@ -131,14 +131,14 @@ const Button = ({
   };
 
   return (
-    <StyledRipple {...updatedButtonProps} {...props} style={computedStyle}>     
-    {props.icon && props.icon.position === "left" && (
+    <StyledRipple {...updatedButtonProps} {...props} style={computedStyle}>
+      {props.icon && props.icon.position === "left" && (
         <MaterialIcons name={props.icon.name} style={props.icon.style} size={props.icon.size} />
       )}
       <Text {...updatedTextProps} style={labelStyle}>
         {label}
       </Text>
-      {props.icon && ( props.icon.position === "right" || !props.icon.position ) && (
+      {props.icon && (props.icon.position === "right" || !props.icon.position) && (
         <MaterialIcons name={props.icon.name} style={props.icon.style} size={props.icon.size} />
       )}
     </StyledRipple>

--- a/src/components/composites/Button/index.tsx
+++ b/src/components/composites/Button/index.tsx
@@ -19,6 +19,8 @@ import { shadows } from "../../../styles";
 
 import { Text, TextProps } from "../../primitives";
 
+import { MaterialIcons } from "@expo/vector-icons";
+
 type RippleProps = BorderProps &
   ColorProps &
   FlexboxProps &
@@ -32,8 +34,18 @@ type RippleProps = BorderProps &
 
 const StyledRipple = styled(Ripple)(color, border, flexbox, layout, space);
 
-type ButtonProps = RippleProps &
-  TouchableWithoutFeedbackProps & {
+type IconProps = {
+  icon?: {
+    name: string;
+    position?: "left" | "right";
+    size?: number;
+    style?: TextStyle | {};
+  };
+}
+
+type ButtonProps = IconProps & RippleProps &
+  TouchableWithoutFeedbackProps & 
+  IconProps & {
     label?: string;
     block?: boolean;
     outline?: boolean;
@@ -119,10 +131,16 @@ const Button = ({
   };
 
   return (
-    <StyledRipple {...updatedButtonProps} {...props} style={computedStyle}>
+    <StyledRipple {...updatedButtonProps} {...props} style={computedStyle}>     
+    {props.icon && props.icon.position === "left" && (
+        <MaterialIcons name={props.icon.name} style={props.icon.style} size={props.icon.size} />
+      )}
       <Text {...updatedTextProps} style={labelStyle}>
         {label}
       </Text>
+      {props.icon && ( props.icon.position === "right" || !props.icon.position ) && (
+        <MaterialIcons name={props.icon.name} style={props.icon.style} size={props.icon.size} />
+      )}
     </StyledRipple>
   );
 };

--- a/src/components/composites/Button/index.tsx
+++ b/src/components/composites/Button/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { StyleSheet, TextStyle, TouchableWithoutFeedbackProps } from "react-native";
 import Ripple from "react-native-material-ripple";
 import styled from "styled-components";
+import { MaterialIcons } from "@expo/vector-icons";
 import {
   BorderProps,
   ColorProps,
@@ -19,7 +20,6 @@ import { shadows } from "../../../styles";
 
 import { Text, TextProps } from "../../primitives";
 
-import { MaterialIcons } from "@expo/vector-icons";
 
 type RippleProps = BorderProps &
   ColorProps &
@@ -38,7 +38,6 @@ type IconProps = {
   icon?: {
     name: string;
     position?: "left" | "right";
-    size?: number;
     style?: TextStyle | {};
   };
 }
@@ -133,13 +132,13 @@ const Button = ({
   return (
     <StyledRipple {...updatedButtonProps} {...props} style={computedStyle}>
       {props.icon && props.icon.position === "left" && (
-        <MaterialIcons name={props.icon.name} style={props.icon.style} size={props.icon.size} />
+        <MaterialIcons name={props.icon.name} style={props.icon.style} />
       )}
       <Text {...updatedTextProps} style={labelStyle}>
         {label}
       </Text>
       {props.icon && (props.icon.position === "right" || !props.icon.position) && (
-        <MaterialIcons name={props.icon.name} style={props.icon.style} size={props.icon.size} />
+        <MaterialIcons name={props.icon.name} style={props.icon.style} />
       )}
     </StyledRipple>
   );


### PR DESCRIPTION
Issue #12 fixed. 
Button supports icons also. 
```
<Button  variant="promote" label="click me!" shadow={4} 
               icon={{
                           position: 'right', 
                           name: 'check', 
                           size: 20, 
                           style: {color: 'red', paddingLeft: 10} 
                         }}
/>
```

![Screenshot 2020-04-23 at 7 47 14 PM](https://user-images.githubusercontent.com/15860517/80109567-43138800-859b-11ea-9f31-d692da96627f.png)
